### PR TITLE
Only update index settings/mapping if migrate_existing_settings is set

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -48,7 +48,7 @@ var Database = module.exports = function(config, collections, cb) {
           "mappings": mappings
         }
     });
-    } else {
+    } else if (self.config.migrate_existing_settings) {
       return self.client.indices.close({index: self.config.index})
       .then(function() {
         if (analysis) {
@@ -70,8 +70,8 @@ var Database = module.exports = function(config, collections, cb) {
         return self.client.indices.open({index: self.config.index})
       })
     }
-   }).catch(function(err) {
-     console.log("waterline-elasticsearch initialization error:", err)
+  }).catch(function(err) {
+    console.log("waterline-elasticsearch initialization error:", err)
     throw new Error(err)
   });
   return this;


### PR DESCRIPTION
We think Bonsai is sometimes taking a while to close/reopen indices, which leads to 503 errors when an app starts up. Since the on-every-startup update of settings/mappings is really only useful for dev, put this behind a flag.

This will cause deploys that DO need mapping/settings to be updated and don't include this flag temporarily in .nxusrc or in the npm run/prod scripts to fail instead.